### PR TITLE
Require rails_pg_adapter

### DIFF
--- a/rails-pg-adapter.gemspec
+++ b/rails-pg-adapter.gemspec
@@ -3,7 +3,7 @@
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require_relative "lib/version"
+require_relative "lib/rails_pg_adapter"
 
 Gem::Specification.new do |spec|
   spec.name = "rails-pg-adapter"


### PR DESCRIPTION
This ensures all files are loaded so RailsPgAdapter.configure can be used during initialization in Rails apps