### PR TITLE
Ensure RailsPgAdapter constant is discoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.2] - 2023-03-29
+
+- Bug fix: Ensure RailsPgAdapter constant is discoverable
+
 ## [0.1.1] - 2023-03-29
 
 - Initial release

--- a/lib/rails-pg-adapter.rb
+++ b/lib/rails-pg-adapter.rb
@@ -1,8 +1,11 @@
+# rubocop:disable Naming/FileName
 # frozen_string_literal: true
 
-require "version"
+require "rails_pg_adapter/version"
 require "rails_pg_adapter/configuration"
 require "rails_pg_adapter/patch"
 
 module RailsPgAdapter
 end
+
+# rubocop:enable Naming/FileName

--- a/lib/rails_pg_adapter/version.rb
+++ b/lib/rails_pg_adapter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsPgAdapter
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/rails-pg-adapter.gemspec
+++ b/rails-pg-adapter.gemspec
@@ -3,7 +3,7 @@
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require_relative "lib/rails_pg_adapter"
+require "rails_pg_adapter/version"
 
 Gem::Specification.new do |spec|
   spec.name = "rails-pg-adapter"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rails_pg_adapter"
+require_relative "../lib/rails-pg-adapter"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Needed to be `rails-pg-extras.rb` over `rails_pg_extras.rb` :facepalm:. This is
because name of the gem has dashes, so bundler will accordingly try to 
require the file on its own. Additionally, other gems like sorbet will be able to
detect this on boot/typecheck as well. 

Also bumping to 0.1.2 for a release.