### PR TITLE
Always prepend the patch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :development do
   gem "pry"
   gem "rake"
   gem "rspec"
+  gem "rspec-rails"
   gem "rubocop"
   gem "rubocop-rails"
   gem "rubocop-rspec"

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "rails_pg_adapter"
+require "rails-pg-adapter"
 # require "rails_pg_adapter/patch"
 # require "rails_pg_adapter/configuration"
 

--- a/lib/rails_pg_adapter/configuration.rb
+++ b/lib/rails_pg_adapter/configuration.rb
@@ -29,10 +29,6 @@ module RailsPgAdapter
     RailsPgAdapter.configuration.add_reset_column_information_patch || false
   end
 
-  def self.enabled?
-    failover_patch? || reset_column_information_patch?
-  end
-
   def self.reset_configuration
     @configuration = Configuration.new({
       add_failover_patch: false,

--- a/lib/rails_pg_adapter/patch.rb
+++ b/lib/rails_pg_adapter/patch.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "active_record/connection_adapters/postgresql_adapter"
 
 module RailsPgAdapter
   module Patch
@@ -66,10 +67,10 @@ module RailsPgAdapter
 
     def warn(msg)
       return unless defined?(Rails)
-        ::Rails.logger.warn("[RailsPgAdapter::Patch] #{msg}")
-      
+      return if Rails.logger.nil?
+      ::Rails.logger.warn("[RailsPgAdapter::Patch] #{msg}")
     end
   end
 end
 
-ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend(RailsPgAdapter::Patch) if RailsPgAdapter.enabled?
+ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend(RailsPgAdapter::Patch)

--- a/rails-pg-adapter.gemspec
+++ b/rails-pg-adapter.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("rails", "< 7.0")
+  spec.add_dependency("rails", "~> 6")
 
   spec.metadata = { "rubygems_mfa_required" => "true" } if spec.respond_to?(:metadata=)
 end

--- a/spec/rails_pg_adapter/configuration_spec.rb
+++ b/spec/rails_pg_adapter/configuration_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe(RailsPgAdapter::Configuration) do
   describe ".failover_patch?" do
     it "returns false" do
       expect(RailsPgAdapter.failover_patch?).to be(false)
-      expect(RailsPgAdapter.enabled?).to be(false)
     end
 
     it "returns true" do
@@ -49,14 +48,12 @@ RSpec.describe(RailsPgAdapter::Configuration) do
         c.add_failover_patch = true
       end
       expect(RailsPgAdapter.failover_patch?).to be(true)
-      expect(RailsPgAdapter.enabled?).to be(true)
     end
   end
 
   describe ".reset_column_information_patch?" do
     it "returns false" do
       expect(RailsPgAdapter.reset_column_information_patch?).to be(false)
-      expect(RailsPgAdapter.enabled?).to be(false)
     end
 
     it "returns true" do
@@ -64,7 +61,6 @@ RSpec.describe(RailsPgAdapter::Configuration) do
         c.add_reset_column_information_patch = true
       end
       expect(RailsPgAdapter.reset_column_information_patch?).to be(true)
-      expect(RailsPgAdapter.enabled?).to be(true)
     end
   end
 end

--- a/spec/rails_pg_adapter/patch_spec.rb
+++ b/spec/rails_pg_adapter/patch_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "active_record"
-require "pry"
-
 class Dummy
   private
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_record/railtie"
+require "rspec/rails"
 require_relative "../lib/rails-pg-adapter"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Depending on how certain Rails apps are loaded the `RailsPgAdapter` configuration would get loaded after the initializer where `RailsPgAdapter::Patch` is loaded, which means `RailsPgAdapter.enabled?` would return to `false` and the `Patch` would not get prepended.

This, fixes that. Now we just read the configuration from a memoized var during runtime and only perform action when the configuration is turned on and the expected error is raised.

Lastly, some minor cleanup to keep the supported versions to rails <6 for now, and consistently in CI (example of a previous [miss](https://github.com/tines/rails-pg-adapter/actions/runs/4602991787/jobs/8132561313), because it was installing Rails7.)