### PR TITLE
Rescue and recover from ActiveRecord::ConnectionNotEstablished

### DIFF
--- a/lib/rails_pg_adapter/patch.rb
+++ b/lib/rails_pg_adapter/patch.rb
@@ -22,13 +22,13 @@ module RailsPgAdapter
 
     def exec_cache(*args)
       super(*args)
-    rescue ::ActiveRecord::StatementInvalid => e
+    rescue ::ActiveRecord::StatementInvalid, ::ActiveRecord::ConnectionNotEstablished => e
       handle_error(e) || raise
     end
 
     def exec_no_cache(*args)
       super(*args)
-    rescue ::ActiveRecord::StatementInvalid => e
+    rescue ::ActiveRecord::StatementInvalid, ::ActiveRecord::ConnectionNotEstablished => e
       handle_error(e) || raise
     end
 

--- a/lib/rails_pg_adapter/version.rb
+++ b/lib/rails_pg_adapter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsPgAdapter
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
Depending on how the DB connections are terminated, `ActiveRecord::ConnectionNotEstablished` can also be raised. In such cases we'd like to rescue and recover just like other cases