### PR TITLE
Retry queries when not in transaction

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,21 +10,21 @@ We pledge to act and interact in ways that contribute to an open, welcoming, div
 
 Examples of behavior that contributes to a positive environment for our community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall community
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -67,7 +67,7 @@ Community leaders will follow these Community Impact Guidelines in determining t
 
 ### 4. Permanent Ban
 
-**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within the community.
 

--- a/lib/rails_pg_adapter/configuration.rb
+++ b/lib/rails_pg_adapter/configuration.rb
@@ -2,11 +2,12 @@
 
 module RailsPgAdapter
   class Configuration
-    attr_accessor :add_failover_patch, :add_reset_column_information_patch
+    attr_accessor :add_failover_patch, :add_reset_column_information_patch, :reconnect_with_backoff
 
     def initialize(attrs)
       self.add_failover_patch = attrs[:add_failover_patch]
       self.add_reset_column_information_patch = attrs[:add_reset_column_information_patch]
+      self.reconnect_with_backoff = attrs[:reconnect_with_backoff]
     end
   end
 
@@ -14,6 +15,7 @@ module RailsPgAdapter
     @configuration ||= Configuration.new({
       add_failover_patch: false,
       add_reset_column_information_patch: false,
+      reconnect_with_backoff: [],
     })
   end
 
@@ -25,6 +27,10 @@ module RailsPgAdapter
     RailsPgAdapter.configuration.add_failover_patch || false
   end
 
+  def self.reconnect_with_backoff?
+    !RailsPgAdapter.configuration.reconnect_with_backoff.empty?
+  end
+
   def self.reset_column_information_patch?
     RailsPgAdapter.configuration.add_reset_column_information_patch || false
   end
@@ -33,6 +39,7 @@ module RailsPgAdapter
     @configuration = Configuration.new({
       add_failover_patch: false,
       add_reset_column_information_patch: false,
+      reconnect_with_backoff: [],
     })
   end
 end

--- a/lib/rails_pg_adapter/patch.rb
+++ b/lib/rails_pg_adapter/patch.rb
@@ -12,6 +12,7 @@ module RailsPgAdapter
       "PG::ConnectionBad",
       "the database system is starting up",
       "connection is closed",
+      "could not connect",
     ].freeze
     CONNECTION_ERROR_RE = /#{CONNECTION_ERROR.map { |w| Regexp.escape(w) }.join("|")}/.freeze
 
@@ -23,20 +24,37 @@ module RailsPgAdapter
     def exec_cache(*args)
       super(*args)
     rescue ::ActiveRecord::StatementInvalid, ::ActiveRecord::ConnectionNotEstablished => e
-      handle_error(e) || raise
+      raise unless supported_errors?(e)
+
+      try_reconnect?(e) ? retry : handle_error(e)
     end
 
     def exec_no_cache(*args)
       super(*args)
     rescue ::ActiveRecord::StatementInvalid, ::ActiveRecord::ConnectionNotEstablished => e
-      handle_error(e) || raise
+      raise unless supported_errors?(e)
+
+      try_reconnect?(e) ? retry : handle_error(e)
+    end
+
+    def try_reconnect?(e)
+      return false if in_transaction?
+      return false unless failover_error?(e.message)
+      return false unless RailsPgAdapter.reconnect_with_backoff?
+
+      begin
+        reconnect!
+        true
+      rescue ::ActiveRecord::ConnectionNotEstablished
+        false
+      end
     end
 
     def handle_error(e)
       if failover_error?(e.message) && RailsPgAdapter.failover_patch?
         warn("clearing connections due to #{e} - #{e.message}")
         disconnect_and_remove_conn!
-        raise
+        raise(e)
       end
 
       return unless missing_column_error?(e.message) && RailsPgAdapter.reset_column_information_patch?
@@ -70,7 +88,43 @@ module RailsPgAdapter
       return if Rails.logger.nil?
       ::Rails.logger.warn("[RailsPgAdapter::Patch] #{msg}")
     end
+
+    def supported_errors?(e)
+      return true if failover_error?(e.message) && RailsPgAdapter.failover_patch?
+      if missing_column_error?(e.message) && RailsPgAdapter.reset_column_information_patch?
+        return true
+      end
+      false
+    end
   end
 end
 
 ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend(RailsPgAdapter::Patch)
+
+# Override new client connection to bake in retries
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgreSQLAdapter
+      class << self
+        old_new_client_method = instance_method(:new_client)
+
+        define_method(:new_client) do |args|
+          sleep_times = RailsPgAdapter.configuration.reconnect_with_backoff.dup
+          begin
+            old_new_client_method.bind(self).call(args)
+          rescue ::ActiveRecord::ConnectionNotEstablished => e
+            raise(e) unless RailsPgAdapter.failover_patch? && RailsPgAdapter.reconnect_with_backoff?
+
+            sleep_time = sleep_times.shift
+            raise unless sleep_time
+            warn(
+              "Could not establish a connection from new_client, retrying again in #{sleep_time} sec.",
+            )
+            sleep(sleep_time)
+            retry
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_pg_adapter/patch.rb
+++ b/lib/rails_pg_adapter/patch.rb
@@ -117,9 +117,7 @@ module ActiveRecord
 
             sleep_time = sleep_times.shift
             raise unless sleep_time
-            warn(
-              "Could not establish a connection from new_client, retrying again in #{sleep_time} sec.",
-            )
+            warn( "Could not establish a connection from new_client, retrying again in #{sleep_time} sec.")
             sleep(sleep_time)
             retry
           end

--- a/lib/rails_pg_adapter/version.rb
+++ b/lib/rails_pg_adapter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsPgAdapter
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/spec/rails_pg_adapter/patch_spec.rb
+++ b/spec/rails_pg_adapter/patch_spec.rb
@@ -1,14 +1,33 @@
 # frozen_string_literal: true
+require "pry"
 
 class Dummy
+  attr_accessor :reconnect_called
+
+  def initialize
+    @reconnect_called = false
+  end
+
   private
 
   def exec_no_cache; end
+
   def disconnect!; end
+
+  def in_transaction?
+    false
+  end
+
+  def reconnect!
+    @reconnect_called = true
+    true
+  end
 end
 
-EXCEPTION_MESSAGE = "PG::ReadOnlySqlTransaction: ERROR:  cannot execute UPDATE in a read-only transaction"
-COLUMN_EXCEPTION_MESSAGE = "PG::UndefinedColumn: ERROR:  column users.template_id does not exist"
+EXCEPTION_MESSAGE =
+  "PG::ReadOnlySqlTransaction: ERROR:  cannot execute UPDATE in a read-only transaction"
+COLUMN_EXCEPTION_MESSAGE =
+  "PG::UndefinedColumn: ERROR:  column users.template_id does not exist"
 
 RSpec.describe(RailsPgAdapter::Patch) do
   before do
@@ -21,36 +40,44 @@ RSpec.describe(RailsPgAdapter::Patch) do
   describe "#exec_cache" do
     it "clears connection when a PG::ReadOnlySqlTransaction exception is raised" do
       allow_any_instance_of(Dummy).to receive(:exec_cache).and_raise(
-        ActiveRecord::StatementInvalid.new(EXCEPTION_MESSAGE)
+        ActiveRecord::StatementInvalid.new(EXCEPTION_MESSAGE),
       )
 
       allow_any_instance_of(Object).to receive(:sleep)
       expect(ActiveRecord::Base.connection_pool).to receive(:remove)
       expect_any_instance_of(Dummy).to receive(:disconnect!)
-      expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache) }.to raise_error(
+      expect {
+        Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache)
+      }.to raise_error(
         ActiveRecord::StatementInvalid,
-        "PG::ReadOnlySqlTransaction: ERROR:  cannot execute UPDATE in a read-only transaction"
+        "PG::ReadOnlySqlTransaction: ERROR:  cannot execute UPDATE in a read-only transaction",
       )
     end
 
     it "does not call clear_all_connections when a general exception is raised" do
-      allow_any_instance_of(Dummy).to receive(:exec_cache).and_raise("Exception")
-      expect(ActiveRecord::Base).not_to receive(:clear_all_connections!)
-      expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache) }.to raise_error(
-        "Exception"
+      allow_any_instance_of(Dummy).to receive(:exec_cache).and_raise(
+        "Exception",
       )
+      expect(ActiveRecord::Base).not_to receive(:clear_all_connections!)
+      expect {
+        Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache)
+      }.to raise_error("Exception")
     end
 
     it "clears schema cache when a PG::UndefinedColumn exception is raised" do
       allow_any_instance_of(Dummy).to receive(:exec_cache).and_raise(
-        ActiveRecord::StatementInvalid.new(COLUMN_EXCEPTION_MESSAGE)
+        ActiveRecord::StatementInvalid.new(COLUMN_EXCEPTION_MESSAGE),
       )
 
-      expect(ActiveRecord::Base).to receive(:descendants).at_least(:once).and_call_original
+      expect(ActiveRecord::Base).to receive(:descendants).at_least(
+        :once,
+      ).and_call_original
 
-      expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache) }.to raise_error(
+      expect {
+        Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache)
+      }.to raise_error(
         ActiveRecord::StatementInvalid,
-        "PG::UndefinedColumn: ERROR:  column users.template_id does not exist"
+        "PG::UndefinedColumn: ERROR:  column users.template_id does not exist",
       )
     end
   end
@@ -58,7 +85,7 @@ RSpec.describe(RailsPgAdapter::Patch) do
   describe "#exec_no_cache" do
     it "calls clear_all_connections when a PG::ReadOnlySqlTransaction exception is raised" do
       allow_any_instance_of(Dummy).to receive(:exec_no_cache).and_raise(
-        ActiveRecord::StatementInvalid.new(EXCEPTION_MESSAGE)
+        ActiveRecord::StatementInvalid.new(EXCEPTION_MESSAGE),
       )
 
       allow_any_instance_of(Object).to receive(:sleep)
@@ -69,14 +96,14 @@ RSpec.describe(RailsPgAdapter::Patch) do
         Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache)
       end.to raise_error(
         ActiveRecord::StatementInvalid,
-        "PG::ReadOnlySqlTransaction: ERROR:  cannot execute UPDATE in a read-only transaction"
+        "PG::ReadOnlySqlTransaction: ERROR:  cannot execute UPDATE in a read-only transaction",
       )
     end
 
     it "calls clear_all_connections when a ActiveRecord::ConnectionNotEstablished exception is raised" do
       msg = "connection is closed"
       allow_any_instance_of(Dummy).to receive(:exec_no_cache).and_raise(
-        ActiveRecord::ConnectionNotEstablished.new(msg)
+        ActiveRecord::ConnectionNotEstablished.new(msg),
       )
 
       allow_any_instance_of(Object).to receive(:sleep)
@@ -85,14 +112,43 @@ RSpec.describe(RailsPgAdapter::Patch) do
 
       expect do
         Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache)
-      end.to raise_error(
-        ActiveRecord::ConnectionNotEstablished,
-        msg
+      end.to raise_error(ActiveRecord::ConnectionNotEstablished, msg)
+    end
+
+    it "calls clear_all_connections when a ActiveRecord::ConnectionNotEstablished retries once and fails" do
+      RailsPgAdapter.configure do |c|
+        c.add_failover_patch = true
+        c.add_reset_column_information_patch = true
+        c.reconnect_with_backoff = [0.5]
+      end
+
+      values = [proc { raise ActiveRecord::ConnectionNotEstablished }] # raise error once
+      allow_any_instance_of(Dummy).to receive(
+        :reconnect!,
+      ).and_wrap_original do |original, *args|
+        values.empty? ? original.call(*args) : values.shift.call
+      end
+
+      msg = "connection is closed"
+      allow_any_instance_of(Dummy).to receive(:exec_no_cache).and_raise(
+        ActiveRecord::ConnectionNotEstablished.new(msg),
       )
+
+      allow_any_instance_of(Object).to receive(:sleep)
+      expect(ActiveRecord::Base.connection_pool).to receive(:remove)
+      expect_any_instance_of(Dummy).to receive(:disconnect!)
+
+      d = Dummy.new
+      expect do
+        d.extend(RailsPgAdapter::Patch).send(:exec_no_cache)
+        expect(d.reconnect_called).to be(true)
+      end.to raise_error(ActiveRecord::ConnectionNotEstablished, msg)
     end
 
     it "does not call clear_all_connections when a general exception is raised" do
-      allow_any_instance_of(Dummy).to receive(:exec_no_cache).and_raise("Exception")
+      allow_any_instance_of(Dummy).to receive(:exec_no_cache).and_raise(
+        "Exception",
+      )
       expect(ActiveRecord::Base).not_to receive(:clear_all_connections!)
       expect do
         Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache)
@@ -101,17 +157,40 @@ RSpec.describe(RailsPgAdapter::Patch) do
 
     it "clears schema cache when a PG::UndefinedColumn exception is raised" do
       allow_any_instance_of(Dummy).to receive(:exec_no_cache).and_raise(
-        ActiveRecord::StatementInvalid.new(COLUMN_EXCEPTION_MESSAGE)
+        ActiveRecord::StatementInvalid.new(COLUMN_EXCEPTION_MESSAGE),
       )
 
-      expect(ActiveRecord::Base).to receive(:descendants).at_least(:once).and_call_original
+      expect(ActiveRecord::Base).to receive(:descendants).at_least(
+        :once,
+      ).and_call_original
 
       expect do
         Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache)
       end.to raise_error(
         ActiveRecord::StatementInvalid,
-        "PG::UndefinedColumn: ERROR:  column users.template_id does not exist"
+        "PG::UndefinedColumn: ERROR:  column users.template_id does not exist",
       )
+    end
+  end
+
+  describe "#new_client" do
+    it "attempts to make a connection, retries once and bubbles up the exception" do
+      RailsPgAdapter.configure do |c|
+        c.add_failover_patch = true
+        c.add_reset_column_information_patch = true
+        c.reconnect_with_backoff = [0.5]
+      end
+
+      expect(PG).to receive(:connect).and_raise(
+        ActiveRecord::ConnectionNotEstablished,
+      ).at_most(:twice)
+      expect(Object).to receive(:sleep).at_most(:once)
+
+      expect do
+        ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new_client(
+          ActiveRecord::Base.connection.instance_variable_get(:@config),
+        )
+      end.to raise_error(ActiveRecord::ConnectionNotEstablished)
     end
   end
 end


### PR DESCRIPTION
We can now retry queries that are no in a transaction. This is also an opt-in
feature when config for `reconnect_with_backoff` is provided. Example

```ruby
RailsPgAdapter.configure do |c|
  c.reconnect_with_backoff = [0.5, 1, 2, 4, 8, 16] # seconds
end
```

This basically gives application more time to catch up towards the tail
end of a fail over and having most requests/jobs succeed with latency being
the trade off.

When `reconnect_with_backoff` is provided - the patch will intercept any
failover message and accordingly attempt to perform a connection for every
figure mentioned inside `reconnect_with_backoff`. This also monkey patches
the `#new_client` method, because when `reconnect!` is called, it eventually
tries to perform `connect` and which then tries to get a new connection from within
`#new_client`. As a result, we perform the back off retry inside `new_client`. In a situation,
when no connection is availed, `ActiveRecord::ConnectionNotEstablished` is bubbled up as the current
behavior