### PR TITLE
Disconnect and remove connection when in read-only

### DIFF
--- a/lib/rails_pg_adapter/version.rb
+++ b/lib/rails_pg_adapter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsPgAdapter
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end


### PR DESCRIPTION
When a connection has detected a read-only mode error chances are the connection is pinned to the, now, reader. In such a case disconnect and remove connection so we can begin a new connection which should (or eventually) will resolve to the new DNS/IP that is the new writer