### PR TITLE
Simplify connection management and introduce upper bound to retries

### DIFF
--- a/lib/rails_pg_adapter/version.rb
+++ b/lib/rails_pg_adapter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsPgAdapter
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end

--- a/spec/rails_pg_adapter/patch_spec.rb
+++ b/spec/rails_pg_adapter/patch_spec.rb
@@ -17,17 +17,11 @@ class Dummy
   def in_transaction?
     false
   end
-
-  def reconnect!
-    @reconnect_called = true
-    true
-  end
 end
 
 EXCEPTION_MESSAGE =
   "PG::ReadOnlySqlTransaction: ERROR:  cannot execute UPDATE in a read-only transaction"
-COLUMN_EXCEPTION_MESSAGE =
-  "PG::UndefinedColumn: ERROR:  column users.template_id does not exist"
+COLUMN_EXCEPTION_MESSAGE = "PG::UndefinedColumn: ERROR:  column users.template_id does not exist"
 
 RSpec.describe(RailsPgAdapter::Patch) do
   before do
@@ -47,22 +41,18 @@ RSpec.describe(RailsPgAdapter::Patch) do
       allow_any_instance_of(Object).to receive(:sleep)
       expect(ActiveRecord::Base.connection_pool).to receive(:remove)
       expect_any_instance_of(Dummy).to receive(:disconnect!)
-      expect {
-        Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache)
-      }.to raise_error(
+      expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache) }.to raise_error(
         ActiveRecord::StatementInvalid,
         "PG::ReadOnlySqlTransaction: ERROR:  cannot execute UPDATE in a read-only transaction",
       )
     end
 
     it "does not call clear_all_connections when a general exception is raised" do
-      allow_any_instance_of(Dummy).to receive(:exec_cache).and_raise(
+      allow_any_instance_of(Dummy).to receive(:exec_cache).and_raise("Exception")
+      expect(ActiveRecord::Base).not_to receive(:clear_all_connections!)
+      expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache) }.to raise_error(
         "Exception",
       )
-      expect(ActiveRecord::Base).not_to receive(:clear_all_connections!)
-      expect {
-        Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache)
-      }.to raise_error("Exception")
     end
 
     it "clears schema cache when a PG::UndefinedColumn exception is raised" do
@@ -70,30 +60,41 @@ RSpec.describe(RailsPgAdapter::Patch) do
         ActiveRecord::StatementInvalid.new(COLUMN_EXCEPTION_MESSAGE),
       )
 
-      expect(ActiveRecord::Base).to receive(:descendants).at_least(
-        :once,
-      ).and_call_original
+      expect(ActiveRecord::Base).to receive(:descendants).at_least(:once).and_call_original
 
-      expect {
-        Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache)
-      }.to raise_error(
+      expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache) }.to raise_error(
         ActiveRecord::StatementInvalid,
         "PG::UndefinedColumn: ERROR:  column users.template_id does not exist",
       )
     end
 
-    it "calls clear_all_connections when a PG::ReadOnlySqlTransaction is retries once and fails" do
+    it "reloads connections when a ActiveRecord::NoDatabaseError is retries once and fails" do
+      msg = "is not currently accepting connections"
       RailsPgAdapter.configure do |c|
         c.add_failover_patch = true
         c.add_reset_column_information_patch = true
         c.reconnect_with_backoff = [0.5]
       end
 
-      values = [proc { raise ActiveRecord::StatementInvalid.new(EXCEPTION_MESSAGE) }] # raise error once
-      allow_any_instance_of(Dummy).to receive(
-        :reconnect!,
-      ).and_wrap_original do |original, *args|
-        values.empty? ? original.call(*args) : values.shift.call
+      allow_any_instance_of(Dummy).to receive(:exec_cache).and_raise(
+        ActiveRecord::NoDatabaseError.new(msg),
+      )
+
+      allow_any_instance_of(Object).to receive(:sleep)
+      expect(ActiveRecord::Base.connection_pool).to receive(:remove).exactly(3).times
+      expect_any_instance_of(Dummy).to receive(:disconnect!).exactly(3).times
+
+      expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache) }.to raise_error(
+        ActiveRecord::NoDatabaseError,
+        msg,
+      )
+    end
+
+    it "reloads connections when a PG::ReadOnlySqlTransaction is retries once and fails" do
+      RailsPgAdapter.configure do |c|
+        c.add_failover_patch = true
+        c.add_reset_column_information_patch = true
+        c.reconnect_with_backoff = [0.5]
       end
 
       allow_any_instance_of(Dummy).to receive(:exec_cache).and_raise(
@@ -101,12 +102,10 @@ RSpec.describe(RailsPgAdapter::Patch) do
       )
 
       allow_any_instance_of(Object).to receive(:sleep)
-      expect(ActiveRecord::Base.connection_pool).to receive(:remove)
-      expect_any_instance_of(Dummy).to receive(:disconnect!)
+      expect(ActiveRecord::Base.connection_pool).to receive(:remove).exactly(3).times
+      expect_any_instance_of(Dummy).to receive(:disconnect!).exactly(3).times
 
-      expect {
-        Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache)
-      }.to raise_error(
+      expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache) }.to raise_error(
         ActiveRecord::StatementInvalid,
         "PG::ReadOnlySqlTransaction: ERROR:  cannot execute UPDATE in a read-only transaction",
       )
@@ -114,7 +113,7 @@ RSpec.describe(RailsPgAdapter::Patch) do
   end
 
   describe "#exec_no_cache" do
-    it "calls clear_all_connections when a PG::ReadOnlySqlTransaction exception is raised" do
+    it "reloads connections when a PG::ReadOnlySqlTransaction exception is raised" do
       allow_any_instance_of(Dummy).to receive(:exec_no_cache).and_raise(
         ActiveRecord::StatementInvalid.new(EXCEPTION_MESSAGE),
       )
@@ -123,15 +122,13 @@ RSpec.describe(RailsPgAdapter::Patch) do
       expect(ActiveRecord::Base.connection_pool).to receive(:remove)
       expect_any_instance_of(Dummy).to receive(:disconnect!)
 
-      expect do
-        Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache)
-      end.to raise_error(
+      expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache) }.to raise_error(
         ActiveRecord::StatementInvalid,
         "PG::ReadOnlySqlTransaction: ERROR:  cannot execute UPDATE in a read-only transaction",
       )
     end
 
-    it "calls clear_all_connections when a ActiveRecord::ConnectionNotEstablished exception is raised" do
+    it "reloads connections when a ActiveRecord::ConnectionNotEstablished exception is raised" do
       msg = "connection is closed"
       allow_any_instance_of(Dummy).to receive(:exec_no_cache).and_raise(
         ActiveRecord::ConnectionNotEstablished.new(msg),
@@ -141,33 +138,27 @@ RSpec.describe(RailsPgAdapter::Patch) do
       expect(ActiveRecord::Base.connection_pool).to receive(:remove)
       expect_any_instance_of(Dummy).to receive(:disconnect!)
 
-      expect do
-        Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache)
-      end.to raise_error(ActiveRecord::ConnectionNotEstablished, msg)
+      expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache) }.to raise_error(
+        ActiveRecord::ConnectionNotEstablished,
+        msg,
+      )
     end
 
-    it "calls clear_all_connections when a ActiveRecord::ConnectionNotEstablished retries once and fails" do
+    it "reloads connections when a ActiveRecord::ConnectionNotEstablished retries once and fails" do
       RailsPgAdapter.configure do |c|
         c.add_failover_patch = true
         c.add_reset_column_information_patch = true
         c.reconnect_with_backoff = [0.5]
       end
 
-      values = [proc { raise ActiveRecord::ConnectionNotEstablished }] # raise error once
-      allow_any_instance_of(Dummy).to receive(
-        :reconnect!,
-      ).and_wrap_original do |original, *args|
-        values.empty? ? original.call(*args) : values.shift.call
-      end
-
       msg = "connection is closed"
       allow_any_instance_of(Dummy).to receive(:exec_no_cache).and_raise(
         ActiveRecord::ConnectionNotEstablished.new(msg),
       )
 
       allow_any_instance_of(Object).to receive(:sleep)
-      expect(ActiveRecord::Base.connection_pool).to receive(:remove)
-      expect_any_instance_of(Dummy).to receive(:disconnect!)
+      expect(ActiveRecord::Base.connection_pool).to receive(:remove).exactly(3).times
+      expect_any_instance_of(Dummy).to receive(:disconnect!).exactly(3).times
 
       d = Dummy.new
       expect do
@@ -176,18 +167,33 @@ RSpec.describe(RailsPgAdapter::Patch) do
       end.to raise_error(ActiveRecord::ConnectionNotEstablished, msg)
     end
 
-    it "calls clear_all_connections when a PG::ReadOnlySqlTransaction is retries once and fails" do
+    it "reloads connections when a ActiveRecord::NoDatabaseError is retries once and fails" do
+      msg = "is not currently accepting connections"
       RailsPgAdapter.configure do |c|
         c.add_failover_patch = true
         c.add_reset_column_information_patch = true
         c.reconnect_with_backoff = [0.5]
       end
 
-      values = [proc { raise ActiveRecord::StatementInvalid.new(EXCEPTION_MESSAGE) }] # raise error once
-      allow_any_instance_of(Dummy).to receive(
-        :reconnect!,
-      ).and_wrap_original do |original, *args|
-        values.empty? ? original.call(*args) : values.shift.call
+      allow_any_instance_of(Dummy).to receive(:exec_no_cache).and_raise(
+        ActiveRecord::NoDatabaseError.new(msg),
+      )
+
+      allow_any_instance_of(Object).to receive(:sleep)
+      expect(ActiveRecord::Base.connection_pool).to receive(:remove).exactly(3).times
+      expect_any_instance_of(Dummy).to receive(:disconnect!).exactly(3).times
+
+      expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache) }.to raise_error(
+        ActiveRecord::NoDatabaseError,
+        msg,
+      )
+    end
+
+    it "reloads connections when a PG::ReadOnlySqlTransaction is retries once and fails" do
+      RailsPgAdapter.configure do |c|
+        c.add_failover_patch = true
+        c.add_reset_column_information_patch = true
+        c.reconnect_with_backoff = [0.5]
       end
 
       allow_any_instance_of(Dummy).to receive(:exec_no_cache).and_raise(
@@ -195,25 +201,21 @@ RSpec.describe(RailsPgAdapter::Patch) do
       )
 
       allow_any_instance_of(Object).to receive(:sleep)
-      expect(ActiveRecord::Base.connection_pool).to receive(:remove)
-      expect_any_instance_of(Dummy).to receive(:disconnect!)
+      expect(ActiveRecord::Base.connection_pool).to receive(:remove).exactly(3).times
+      expect_any_instance_of(Dummy).to receive(:disconnect!).exactly(3).times
 
-      expect {
-        Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache)
-      }.to raise_error(
+      expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache) }.to raise_error(
         ActiveRecord::StatementInvalid,
         "PG::ReadOnlySqlTransaction: ERROR:  cannot execute UPDATE in a read-only transaction",
       )
     end
 
     it "does not call clear_all_connections when a general exception is raised" do
-      allow_any_instance_of(Dummy).to receive(:exec_no_cache).and_raise(
+      allow_any_instance_of(Dummy).to receive(:exec_no_cache).and_raise("Exception")
+      expect(ActiveRecord::Base).not_to receive(:clear_all_connections!)
+      expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache) }.to raise_error(
         "Exception",
       )
-      expect(ActiveRecord::Base).not_to receive(:clear_all_connections!)
-      expect do
-        Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache)
-      end.to raise_error("Exception")
     end
 
     it "clears schema cache when a PG::UndefinedColumn exception is raised" do
@@ -221,13 +223,9 @@ RSpec.describe(RailsPgAdapter::Patch) do
         ActiveRecord::StatementInvalid.new(COLUMN_EXCEPTION_MESSAGE),
       )
 
-      expect(ActiveRecord::Base).to receive(:descendants).at_least(
-        :once,
-      ).and_call_original
+      expect(ActiveRecord::Base).to receive(:descendants).at_least(:once).and_call_original
 
-      expect do
-        Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache)
-      end.to raise_error(
+      expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache) }.to raise_error(
         ActiveRecord::StatementInvalid,
         "PG::UndefinedColumn: ERROR:  column users.template_id does not exist",
       )
@@ -242,16 +240,33 @@ RSpec.describe(RailsPgAdapter::Patch) do
         c.reconnect_with_backoff = [0.5]
       end
 
-      expect(PG).to receive(:connect).and_raise(
-        ActiveRecord::ConnectionNotEstablished,
-      ).at_most(:twice)
-      expect(Object).to receive(:sleep).at_most(:once)
+      expect(PG).to receive(:connect)
+        .and_raise(ActiveRecord::ConnectionNotEstablished)
+        .exactly(:twice)
+      expect(Object).to receive(:sleep).exactly(:once)
 
       expect do
         ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new_client(
           ActiveRecord::Base.connection.instance_variable_get(:@config),
         )
       end.to raise_error(ActiveRecord::ConnectionNotEstablished)
+    end
+
+    it "attempts to make a connection when ActiveRecord::NoDatabaseError is raised, retries once and bubbles up the exception" do
+      RailsPgAdapter.configure do |c|
+        c.add_failover_patch = true
+        c.add_reset_column_information_patch = true
+        c.reconnect_with_backoff = [0.5]
+      end
+
+      expect(PG).to receive(:connect).and_raise(ActiveRecord::NoDatabaseError).exactly(:twice)
+      expect(Object).to receive(:sleep).exactly(:once)
+
+      expect do
+        ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new_client(
+          ActiveRecord::Base.connection.instance_variable_get(:@config),
+        )
+      end.to raise_error(ActiveRecord::NoDatabaseError)
     end
   end
 end


### PR DESCRIPTION
This change is introducing a few things

- First - simplifying the connection cleanup logic. Instead of reconnecting
or anything, we simply disconnect and remove the connection. The exception
is bubbled up into the app. We don't try to re-connect. This makes the state
of a connection and query all wonky.
- Next - We have an upper limit to retries inside the rescue block for `exec_cache`
and `exec_no_cache`, to avoid retry loops. The upper limit is the same
as the back off retries.
- Lastly, it also performs the same failover logic handling for `ActiveRecord::NoDatabaseError`.
Say when too many connections or other connection issues are raised. `ActiveRecord::NoDatabaseError`
is an interesting error class to rescue but we filter out based on the error message `is not currently accepting connections`.
Internal testing showed this was helpful in retrying queries when switching between blue/green databases
during logical replication