### PR TITLE
Retry on too many connections error as well

### DIFF
--- a/lib/rails_pg_adapter/patch.rb
+++ b/lib/rails_pg_adapter/patch.rb
@@ -14,6 +14,7 @@ module RailsPgAdapter
       "connection is closed",
       "could not connect",
       "is not currently accepting connections",
+      "too many connections"
     ].freeze
     CONNECTION_ERROR_RE = /#{CONNECTION_ERROR.map { |w| Regexp.escape(w) }.join("|")}/.freeze
 

--- a/lib/rails_pg_adapter/version.rb
+++ b/lib/rails_pg_adapter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsPgAdapter
-  VERSION = "0.1.8"
+  VERSION = "0.1.9"
 end


### PR DESCRIPTION
When a too many connections error is thrown, we can perform the same retry with backoff (if opted in). This is thrown on a ActiveRecord::NoDatabaseError class, which was made stricter in the last change. Hence, bringing the same retry mechanism back