### PR TITLE
Attempt to reset transaction in the hopes of retry

### DIFF
--- a/lib/rails_pg_adapter/patch.rb
+++ b/lib/rails_pg_adapter/patch.rb
@@ -84,11 +84,13 @@ module RailsPgAdapter
     end
 
     def try_reconnect?(e)
-      return false if in_transaction?
       return false unless ::RailsPgAdapter::Patch.failover_error?(e.message)
       return false unless ::RailsPgAdapter.reconnect_with_backoff?
 
       begin
+        if in_transaction?
+          reset!
+        end
         disconnect_conn!
         true
       rescue ::ActiveRecord::ConnectionNotEstablished


### PR DESCRIPTION
When a database is failing over we'd like to retry the whole transaction again. It usually throws an eror message like `cannot execute INSERT in a read-only transaction.`. Such cases are safe for retries. For safety measures we reset the connection which issues a rollback and we attempt for a retry