### PR TITLE
Attempt a re-connect before a retry

### DIFF
--- a/lib/rails_pg_adapter/version.rb
+++ b/lib/rails_pg_adapter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsPgAdapter
-  VERSION = "0.1.10"
+  VERSION = "0.1.11"
 end

--- a/spec/rails_pg_adapter/patch_spec.rb
+++ b/spec/rails_pg_adapter/patch_spec.rb
@@ -14,6 +14,8 @@ class Dummy
 
   def disconnect!; end
 
+  def connect; end
+
   def in_transaction?
     false
   end
@@ -137,7 +139,6 @@ RSpec.describe(RailsPgAdapter::Patch) do
       allow_any_instance_of(Object).to receive(:sleep)
       expect(ActiveRecord::Base.connection_pool).to receive(:remove)
       expect_any_instance_of(Dummy).to receive(:disconnect!)
-
       expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache) }.to raise_error(
         ActiveRecord::ConnectionNotEstablished,
         msg,
@@ -159,6 +160,7 @@ RSpec.describe(RailsPgAdapter::Patch) do
       allow_any_instance_of(Object).to receive(:sleep)
       expect(ActiveRecord::Base.connection_pool).to receive(:remove).exactly(3).times
       expect_any_instance_of(Dummy).to receive(:disconnect!).exactly(3).times
+      expect_any_instance_of(Dummy).to receive(:connect).once
 
       d = Dummy.new
       expect do
@@ -182,6 +184,7 @@ RSpec.describe(RailsPgAdapter::Patch) do
       allow_any_instance_of(Object).to receive(:sleep)
       expect(ActiveRecord::Base.connection_pool).to receive(:remove).exactly(3).times
       expect_any_instance_of(Dummy).to receive(:disconnect!).exactly(3).times
+      expect_any_instance_of(Dummy).to receive(:connect).once
 
       expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache) }.to raise_error(
         ActiveRecord::NoDatabaseError,
@@ -203,6 +206,7 @@ RSpec.describe(RailsPgAdapter::Patch) do
       allow_any_instance_of(Object).to receive(:sleep)
       expect(ActiveRecord::Base.connection_pool).to receive(:remove).exactly(3).times
       expect_any_instance_of(Dummy).to receive(:disconnect!).exactly(3).times
+      expect_any_instance_of(Dummy).to receive(:connect).once
 
       expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache) }.to raise_error(
         ActiveRecord::StatementInvalid,


### PR DESCRIPTION
This way we can attempt to retry a query with a new connection. This is especially useful during failovers where the connection may be pinned to a writer. Instead we try a new connection and then retry the query. Additionally, when we retry transaction block internally, we will be doing it on the new connection. 

This isn't issue for transactions, since we re-raise and bubble up the issues