### PR TITLE
Slight refactor and reduce multiple disconnect attempts

### DIFF
--- a/lib/rails_pg_adapter/version.rb
+++ b/lib/rails_pg_adapter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsPgAdapter
-  VERSION = "0.1.11"
+  VERSION = "0.1.12"
 end


### PR DESCRIPTION
This makes the code easier to follow and also remove the redundant call for `disconnect_conn!` from `try_connect?`. We can just perform that from `handle_activerecord_error` now and keep the logic much simpler to follow