### PR TITLE
Use throw_away! instead and capture state of transaction and re-raise accordingly

### DIFF
--- a/lib/rails_pg_adapter/patch.rb
+++ b/lib/rails_pg_adapter/patch.rb
@@ -103,7 +103,7 @@ module RailsPgAdapter
     def handle_activerecord_error(e)
       return unless ::RailsPgAdapter::Patch.failover_error?(e.message)
       warn("clearing connections due to #{e} - #{e.message}")
-      disconnect_conn!
+      throw_away!
     end
 
     def handle_schema_cache_error(e)
@@ -112,11 +112,6 @@ module RailsPgAdapter
 
       internal_clear_schema_cache!
       raise(e)
-    end
-
-    def disconnect_conn!
-      disconnect!
-      ::ActiveRecord::Base.connection_pool.remove(::ActiveRecord::Base.connection)
     end
 
     def internal_clear_schema_cache!

--- a/lib/rails_pg_adapter/version.rb
+++ b/lib/rails_pg_adapter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsPgAdapter
-  VERSION = "0.1.12"
+  VERSION = "0.1.13"
 end

--- a/spec/rails_pg_adapter/patch_spec.rb
+++ b/spec/rails_pg_adapter/patch_spec.rb
@@ -12,7 +12,7 @@ class Dummy
 
   def exec_no_cache; end
 
-  def disconnect!; end
+  def throw_away!; end
 
   def connect; end
 
@@ -41,8 +41,7 @@ RSpec.describe(RailsPgAdapter::Patch) do
       )
 
       allow_any_instance_of(Object).to receive(:sleep)
-      expect(ActiveRecord::Base.connection_pool).to receive(:remove)
-      expect_any_instance_of(Dummy).to receive(:disconnect!)
+      expect_any_instance_of(Dummy).to receive(:throw_away!)
       expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache) }.to raise_error(
         ActiveRecord::StatementInvalid,
         "PG::ReadOnlySqlTransaction: ERROR:  cannot execute UPDATE in a read-only transaction",
@@ -83,8 +82,7 @@ RSpec.describe(RailsPgAdapter::Patch) do
       )
 
       allow_any_instance_of(Object).to receive(:sleep)
-      expect(ActiveRecord::Base.connection_pool).to receive(:remove).exactly(3).times
-      expect_any_instance_of(Dummy).to receive(:disconnect!).exactly(3).times
+      expect_any_instance_of(Dummy).to receive(:throw_away!).exactly(3).times
 
       expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache) }.to raise_error(
         ActiveRecord::NoDatabaseError,
@@ -104,8 +102,7 @@ RSpec.describe(RailsPgAdapter::Patch) do
       )
 
       allow_any_instance_of(Object).to receive(:sleep)
-      expect(ActiveRecord::Base.connection_pool).to receive(:remove).exactly(3).times
-      expect_any_instance_of(Dummy).to receive(:disconnect!).exactly(3).times
+      expect_any_instance_of(Dummy).to receive(:throw_away!).exactly(3).times
 
       expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_cache) }.to raise_error(
         ActiveRecord::StatementInvalid,
@@ -121,8 +118,7 @@ RSpec.describe(RailsPgAdapter::Patch) do
       )
 
       allow_any_instance_of(Object).to receive(:sleep)
-      expect(ActiveRecord::Base.connection_pool).to receive(:remove)
-      expect_any_instance_of(Dummy).to receive(:disconnect!)
+      expect_any_instance_of(Dummy).to receive(:throw_away!)
 
       expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache) }.to raise_error(
         ActiveRecord::StatementInvalid,
@@ -137,8 +133,7 @@ RSpec.describe(RailsPgAdapter::Patch) do
       )
 
       allow_any_instance_of(Object).to receive(:sleep)
-      expect(ActiveRecord::Base.connection_pool).to receive(:remove)
-      expect_any_instance_of(Dummy).to receive(:disconnect!)
+      expect_any_instance_of(Dummy).to receive(:throw_away!)
       expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache) }.to raise_error(
         ActiveRecord::ConnectionNotEstablished,
         msg,
@@ -158,8 +153,7 @@ RSpec.describe(RailsPgAdapter::Patch) do
       )
 
       allow_any_instance_of(Object).to receive(:sleep)
-      expect(ActiveRecord::Base.connection_pool).to receive(:remove).exactly(3).times
-      expect_any_instance_of(Dummy).to receive(:disconnect!).exactly(3).times
+      expect_any_instance_of(Dummy).to receive(:throw_away!).exactly(3).times
       expect_any_instance_of(Dummy).to receive(:connect).once
 
       d = Dummy.new
@@ -182,8 +176,7 @@ RSpec.describe(RailsPgAdapter::Patch) do
       )
 
       allow_any_instance_of(Object).to receive(:sleep)
-      expect(ActiveRecord::Base.connection_pool).to receive(:remove).exactly(3).times
-      expect_any_instance_of(Dummy).to receive(:disconnect!).exactly(3).times
+      expect_any_instance_of(Dummy).to receive(:throw_away!).exactly(3).times
       expect_any_instance_of(Dummy).to receive(:connect).once
 
       expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache) }.to raise_error(
@@ -204,8 +197,7 @@ RSpec.describe(RailsPgAdapter::Patch) do
       )
 
       allow_any_instance_of(Object).to receive(:sleep)
-      expect(ActiveRecord::Base.connection_pool).to receive(:remove).exactly(3).times
-      expect_any_instance_of(Dummy).to receive(:disconnect!).exactly(3).times
+      expect_any_instance_of(Dummy).to receive(:throw_away!).exactly(3).times
       expect_any_instance_of(Dummy).to receive(:connect).once
 
       expect { Dummy.new.extend(RailsPgAdapter::Patch).send(:exec_no_cache) }.to raise_error(


### PR DESCRIPTION
#### Use throw_away!
 TIL about [`throw_away!`](https://github.com/rails/rails/blob/8226bba57f2dea0b97c02b4df4d0e9638644de03/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L739...L741) and I think it helped me see the issue
internally we've been having too. It removes from the pool first
and then disconnects. Hence, using the same function instead of baking our own

#### Capture state of transaction and re-raise accordingly

If we had retries turned on, the state of `in_transaction?` would get reset and we
could accidentally end up re-trying a query from within transaction. So, we now keep
track of it before the retry block and re-raise the exception early if a query is part of a transaction.