### PR TITLE
Lock Rails to v6

### DIFF
--- a/rails-pg-adapter.gemspec
+++ b/rails-pg-adapter.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("rails", "~> 6")
+  spec.add_dependency("rails", "~> 6", "<7")
 
   spec.metadata = { "rubygems_mfa_required" => "true" } if spec.respond_to?(:metadata=)
 end


### PR DESCRIPTION
We haven't tested this with Rails 7 and Rails 7 has some auto reconnect and retry features for read queries too, so part of the feature set is also covered

Closes: https://github.com/tines/rails-pg-adapter/pull/21/