### PR TITLE
Capture the database system is in recovery mode error

### DIFF
--- a/lib/rails_pg_adapter/patch.rb
+++ b/lib/rails_pg_adapter/patch.rb
@@ -16,6 +16,7 @@ module RailsPgAdapter
       "is not currently accepting connections",
       "too many connections",
       "Connection refused",
+      "the database system is in recovery mode"
     ].freeze
     CONNECTION_ERROR_RE = /#{CONNECTION_ERROR.map { |w| Regexp.escape(w) }.join("|")}/.freeze
 


### PR DESCRIPTION
This allows to retry queries which experience: the database system is in recovery mode